### PR TITLE
Incorrect loadChildren format

### DIFF
--- a/AngularUI/src/app/layouts/welcome-layout/welcome-layout-routing.routing.ts
+++ b/AngularUI/src/app/layouts/welcome-layout/welcome-layout-routing.routing.ts
@@ -4,7 +4,7 @@ import { CommonAuthModule } from 'app/auth/common-auth.module';
 export const WelcomeLayoutRouting: Routes = [
   {
     path: '',
-    loadChildren: () => import('../../auth/common-auth.module').then(m => CommonAuthModule)
+    loadChildren: () => import('../../auth/common-auth.module').then(m => m.CommonAuthModule)
   }
 ];
 


### PR DESCRIPTION
`ng server` will work in this format, but when you try to use `ng build --prod` it fails. Quick fix to prefix with module. This will work for both